### PR TITLE
修复dev模式下weex publicPath端口不一致问题

### DIFF
--- a/lib/weex.js
+++ b/lib/weex.js
@@ -11,6 +11,11 @@ class WebpackWeexBuilder extends WebpackBaseBuilder(EasyWebpack.WebpackClientBui
     this.setDefine('process.env.PLATFORM', '"weex"');
   }
 
+  setPort(port) {
+    super.setPort(port);
+    this.config.port += 1;
+  }
+
   // weex 只能一个js文件，不能提取
   setCommonsChunkLib() {
 


### PR DESCRIPTION
根据webpack端口自增1，临时解决